### PR TITLE
add support for stylus files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jest-transform-css
 
-A Jest transformer which enables importing CSS into Jest's `jsdom`.
+A Jest transformer which enables importing CSS into Jest's `jsdom`.  Additionally, it supports applicatitons which uses stylus.
 
 **If you are not here for Visual Regression Testing, but just want to make your tests work with CSS Modules, then you are likley looking for https://github.com/keyanzhang/identity-obj-proxy/.**
 
@@ -72,6 +72,16 @@ transform: {
 }
 ```
 
+If you are using stylus
+
+```
+// in the Jest config
+transform: {
+  "^.+\\.js$": "babel-jest",
+ "^.+\\.(styl|css)$": "jest-transform-css",
+}
+```
+
 > Notice that `babel-jest` gets added as well.
 >
 > The `babel-jest` code preprocessor is enabled by default, when no other preprocessors are added. As `jest-transform-css` is a code preprocessor, `babel-jest` gets disabled when `jest-transform-css` is added.
@@ -94,7 +104,19 @@ module.exports = {
 };
 ```
 
-This will enable CSS module transformation for all CSS files transformed by `jest-transform-css`.
+In case, you are using stylus
+
+```js
+// jesttransformcss.config.js
+
+module.exports = {
+  modules: true,
+  stylus: true,
+  pathToStyles: 'src/styles'  // this is the path where your styles reside. used for resolving path provided by `composes` keyword in stylus
+};
+```
+
+This will enable CSS module transformation for all CSS and Stylus files transformed by `jest-transform-css`.
 
 If your setup uses both, CSS modules and regular CSS, then you can determine how to load each file individually by specifying a function:
 
@@ -107,6 +129,9 @@ module.exports = {
 ```
 
 This will load all files with `.mod.css` as CSS modules and load all other files as regular CSS. Notice that the function will only be called for whichever regex you provided in the `transform` option of the Jest config.
+
+
+**Note**: *If your stylus files are using `require` to import styles from other stylus files, you will run into some issues since stylus cannot compile a relative path. You either will have to provide an absolute path of the file or will need to change the path into a webpack alias, eg. ~styles, and regex the `~` with the root path. This change will have to be done in this package itself.*
 
 ## Further setup
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "cross-spawn": "6.0.5",
     "postcss-load-config": "2.0.0",
     "postcss-modules": "1.3.2",
-    "style-inject": "0.3.0"
+    "style-inject": "0.3.0",
+    "stylus": "^0.54.7"
   },
   "devDependencies": {
     "postcss": "^7.0.2"

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const stylus = require('stylus');
+const path = require('path');
+
+module.exports = {
+
+    checkForComposes(src) {
+        return src.includes('composes');
+    },
+
+    extractCSSFromComposedFile(src, appDir, pathToStyles) {
+        let originalSource = src;
+        const hasComposes = originalSource.includes('composes');
+        if ( hasComposes ) {
+            //grab the file thats is used for composes
+            const lines = originalSource.match(/\bcomposes\W+(?:\w+\W+){1,2}?from\b.*/g);
+            
+            let newStr;
+            lines.map(line => {
+                //extract the file name from line containing composes, 
+                const composedFileName = path.resolve(appDir, pathToStyles +  line.substring(line.indexOf('!')+2, line.length-1));
+                const strComposed = fs.readFileSync(composedFileName , 'utf8')
+                const composedRender = stylus(strComposed).render();
+                newStr = composedRender + originalSource + `\n`;
+            })
+            //replace the source with the source of the compiled file
+            originalSource = newStr.replace(/from.*?[\n|\z]/g, `\n`);
+            return originalSource;
+
+        } else {
+            return originalSource;
+        }
+
+    },
+}


### PR DESCRIPTION
Thanks for creating this package.. it was definitely a great starting point for me to try out visual testing.. Our application uses stylus, so I had to modify this package to support stylus. Thought it might be a good addition to this package to support stylus.  

Please let me know if it makes more sense to create a separate package but since not much addition, I think it can be combined with this. I have added some extra instructions to README to support stylus set up. Comments are welcome!

Example app where this is used: https://github.com/abhagupta/visual-regression-testing-create-react-app-example