### PR TITLE
Update getCacheKey to support Jest 27

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,13 @@ const explorer = cosmiconfig("jesttransformcss");
 const transformConfig = explorer.searchSync();
 
 module.exports = {
-  getCacheKey: (fileData, filename, configString, { instrument }) => {
+  getCacheKey: (fileData, filename, configString, options) => {
+    // Jest 27 passes a single options bag which contains `configString` rather than as a separate argument
+    if (!options) {
+      options = configString;
+      configString = options.configString;
+    }
+    const { instrument} = options;
     return (
       crypto
         .createHash("md5")


### PR DESCRIPTION
Following the commit: https://github.com/facebook/fbjs/pull/408/files#diff-f8bde41635f06063d5726077e7c01e3e3e0ef1fb59296925368fdc3138242a1a