### PR TITLE
Update postcss-load-config dependency to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "common-tags": "1.8.2",
         "cross-spawn": "7.0.3",
-        "postcss-load-config": "2.0.0",
+        "postcss-load-config": "4.0.1",
         "postcss-modules": "4.3.1",
         "style-inject": "0.3.0"
       },
@@ -22,31 +22,11 @@
         "postcss": "^8.4.12"
       }
     },
-    "node_modules/argparse": {
-      "version": "1.0.10",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "node_modules/common-tags": {
       "version": "1.8.2",
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/cosmiconfig": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.9.0",
-        "parse-json": "^4.0.0",
-        "require-from-string": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/cross-spawn": {
@@ -66,24 +46,6 @@
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/error-ex": {
-      "version": "1.3.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
       },
       "engines": {
         "node": ">=4"
@@ -110,55 +72,17 @@
         "postcss": "^8.1.0"
       }
     },
-    "node_modules/import-cwd": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "import-from": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/import-from": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "resolve-from": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "license": "MIT"
-    },
-    "node_modules/is-directory": {
-      "version": "0.3.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "license": "ISC"
     },
-    "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
+    "node_modules/lilconfig": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
+      "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
+      "engines": {
+        "node": ">=10"
       }
-    },
-    "node_modules/json-parse-better-errors": {
-      "version": "1.0.2",
-      "license": "MIT"
     },
     "node_modules/loader-utils": {
       "version": "3.2.0",
@@ -179,17 +103,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/parse-json": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/path-key": {
@@ -226,14 +139,31 @@
       }
     },
     "node_modules/postcss-load-config": {
-      "version": "2.0.0",
-      "license": "MIT",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.1.tgz",
+      "integrity": "sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==",
       "dependencies": {
-        "cosmiconfig": "^4.0.0",
-        "import-cwd": "^2.0.0"
+        "lilconfig": "^2.0.5",
+        "yaml": "^2.1.1"
       },
       "engines": {
-        "node": ">= 4"
+        "node": ">= 14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": ">=8.0.9",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
       }
     },
     "node_modules/postcss-modules": {
@@ -319,20 +249,6 @@
       "version": "4.2.0",
       "license": "MIT"
     },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/resolve-from": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "license": "MIT",
@@ -356,10 +272,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "license": "BSD-3-Clause"
     },
     "node_modules/string-hash": {
       "version": "1.1.3",
@@ -385,26 +297,19 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/yaml": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.2.tgz",
+      "integrity": "sha512-VSdf2/K3FqAetooKQv45Hcu6sA00aDgWZeGcG6V9IYJnVLTnb6988Tie79K5nx2vK7cEpf+yW8Oy+7iPAbdiHA==",
+      "engines": {
+        "node": ">= 14"
+      }
     }
   },
   "dependencies": {
-    "argparse": {
-      "version": "1.0.10",
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "common-tags": {
       "version": "1.8.2"
-    },
-    "cosmiconfig": {
-      "version": "4.0.0",
-      "requires": {
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.9.0",
-        "parse-json": "^4.0.0",
-        "require-from-string": "^2.0.1"
-      }
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -416,15 +321,6 @@
     },
     "cssesc": {
       "version": "3.0.0"
-    },
-    "error-ex": {
-      "version": "1.3.2",
-      "requires": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
-    "esprima": {
-      "version": "4.0.1"
     },
     "generic-names": {
       "version": "4.0.0",
@@ -439,36 +335,13 @@
       "version": "5.1.0",
       "requires": {}
     },
-    "import-cwd": {
-      "version": "2.1.0",
-      "requires": {
-        "import-from": "^2.1.0"
-      }
-    },
-    "import-from": {
-      "version": "2.1.0",
-      "requires": {
-        "resolve-from": "^3.0.0"
-      }
-    },
-    "is-arrayish": {
-      "version": "0.2.1"
-    },
-    "is-directory": {
-      "version": "0.3.1"
-    },
     "isexe": {
       "version": "2.0.0"
     },
-    "js-yaml": {
-      "version": "3.14.1",
-      "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      }
-    },
-    "json-parse-better-errors": {
-      "version": "1.0.2"
+    "lilconfig": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
+      "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg=="
     },
     "loader-utils": {
       "version": "3.2.0"
@@ -478,13 +351,6 @@
     },
     "nanoid": {
       "version": "3.3.2"
-    },
-    "parse-json": {
-      "version": "4.0.0",
-      "requires": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      }
     },
     "path-key": {
       "version": "3.1.1"
@@ -501,10 +367,12 @@
       }
     },
     "postcss-load-config": {
-      "version": "2.0.0",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.1.tgz",
+      "integrity": "sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==",
       "requires": {
-        "cosmiconfig": "^4.0.0",
-        "import-cwd": "^2.0.0"
+        "lilconfig": "^2.0.5",
+        "yaml": "^2.1.1"
       }
     },
     "postcss-modules": {
@@ -554,12 +422,6 @@
     "postcss-value-parser": {
       "version": "4.2.0"
     },
-    "require-from-string": {
-      "version": "2.0.2"
-    },
-    "resolve-from": {
-      "version": "3.0.0"
-    },
     "shebang-command": {
       "version": "2.0.0",
       "requires": {
@@ -571,9 +433,6 @@
     },
     "source-map-js": {
       "version": "1.0.2"
-    },
-    "sprintf-js": {
-      "version": "1.0.3"
     },
     "string-hash": {
       "version": "1.1.3"
@@ -589,6 +448,11 @@
       "requires": {
         "isexe": "^2.0.0"
       }
+    },
+    "yaml": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.2.tgz",
+      "integrity": "sha512-VSdf2/K3FqAetooKQv45Hcu6sA00aDgWZeGcG6V9IYJnVLTnb6988Tie79K5nx2vK7cEpf+yW8Oy+7iPAbdiHA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "common-tags": "1.8.2",
     "cross-spawn": "7.0.3",
-    "postcss-load-config": "2.0.0",
+    "postcss-load-config": "4.0.1",
     "postcss-modules": "4.3.1",
     "style-inject": "0.3.0"
   },


### PR DESCRIPTION
I've experienced problems with resolving postcss plugins defined in .postcssrc.json or in postcss.config.js. New version solved them.
My current working setup is `.postcssrc.json` file in the root directory:
```
{
  "plugins": {
    "postcss-nested": {},
    "autoprefixer": {}
  }
}
```