### PR TITLE
chore(deps): update cross-spawn to v7.0.5 to address security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "common-tags": "1.8.2",
-    "cross-spawn": "7.0.3",
+    "cross-spawn": "7.0.5",
     "postcss-load-config": "4.0.1",
     "postcss-modules": "4.3.1",
     "style-inject": "0.3.0"


### PR DESCRIPTION
Updated the version of cross-spawn from v7.0.3 to v7.0.5 in the package.json of jest-transform-css to mitigate a security vulnerability identified in GHSA-3xgq-45jj-v275.